### PR TITLE
increase timeouts for making an HTTP connection, and receiving a response, temporarily for the demo

### DIFF
--- a/lib/invoke_lambda/signed_request.ex
+++ b/lib/invoke_lambda/signed_request.ex
@@ -22,7 +22,8 @@ defmodule InvokeLambda.SignedRequest do
     HTTPoison.post(
       params.url,
       params.body,
-      params.headers
+      params.headers,
+      [recv_timeout: 15000, timeout: 15000]
     )
     |> format_response
   end

--- a/test/e2e_test.exs
+++ b/test/e2e_test.exs
@@ -15,6 +15,8 @@ defmodule E2eTest do
   @lambda_role_arn TestHelper.example_lambda_role_arn()
   @instance_role TestHelper.example_instance_role_name()
   @expected_meta_data_url TestHelper.expected_meta_data_url(@instance_role)
+  @expected_timeouts [recv_timeout: 15000, timeout: 15000]
+
   @options %{
     lambda_role_arn: @lambda_role_arn,
     instance_role_name: @instance_role,
@@ -47,8 +49,8 @@ defmodule E2eTest do
        [
          get!: fn @expected_meta_data_url -> TestHelper.expected_meta_data_response() end,
          post: fn
-           @expected_sts_url, _, _ -> @expected_sts_response
-           @expected_invocation_url, _, _ -> @invocation_result
+           @expected_sts_url, _, _, _ -> @expected_sts_response
+           @expected_invocation_url, _, _, _ -> @invocation_result
          end
        ]},
       {Crypto, [],
@@ -69,11 +71,12 @@ defmodule E2eTest do
         HTTPoison.post(
           @expected_invocation_url,
           @expected_invocation_body,
-          @expected_invoke_headers
+          @expected_invoke_headers,
+          @expected_timeouts
         )
       )
 
-      assert_called(HTTPoison.post(@expected_sts_url, @expected_sts_body, @expected_sts_headers))
+      assert_called(HTTPoison.post(@expected_sts_url, @expected_sts_body, @expected_sts_headers, @expected_timeouts))
 
       assert_called(HTTPoison.get!(@expected_meta_data_url))
 

--- a/test/lambda_test.exs
+++ b/test/lambda_test.exs
@@ -19,12 +19,13 @@ defmodule LambdaTest do
      "AWS4-HMAC-SHA256 Credential=<aws-access-key>/20190207/eu-west-1/lambda/aws4_request, SignedHeaders=host;x-amz-date, Signature=997d9b9a97fd73b86986255e15ab88fcadeb5d5e3bcb0177c05b77f0f4f95436"},
     {"x-amz-security-token", "<aws-security-token>"}
   ]
+  @expected_timeouts [recv_timeout: 15000, timeout: 15000]
 
   test "send post to lambda" do
     with_mocks([
       {HTTPoison, [],
        [
-         post: fn _url, _body, _headers -> @expected_lambda_response end
+         post: fn _url, _body, _headers, _options -> @expected_lambda_response end
        ]},
       {Utils, [],
        [
@@ -52,7 +53,8 @@ defmodule LambdaTest do
         HTTPoison.post(
           @expected_lambda_url,
           @expected_lambda_body,
-          @expected_lambda_headers
+          @expected_lambda_headers,
+          @expected_timeouts
         )
       )
 

--- a/test/sts_test.exs
+++ b/test/sts_test.exs
@@ -25,12 +25,13 @@ defmodule StsTest do
      "AWS4-HMAC-SHA256 Credential=<aws-access-key>/20190207/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date, Signature=3c0bd50b6b469fc3f9d308aa2e34a89e190f9c0c50822053b0e415bafddde355"},
     {"x-amz-security-token", "<aws-security-token>"}
   ]
+  @expected_timeouts [recv_timeout: 15000, timeout: 15000]
 
   test "send post to sts" do
     with_mocks([
       {HTTPoison, [],
        [
-         post: fn _url, _body, _headers -> @expected_sts_response end
+         post: fn _url, _body, _headers, _options -> @expected_sts_response end
        ]},
       {Utils, [],
        [
@@ -56,7 +57,8 @@ defmodule StsTest do
         HTTPoison.post(
           @expected_sts_url,
           @expected_sts_body,
-          @expected_sts_headers
+          @expected_sts_headers,
+          @expected_timeouts
         )
       )
 


### PR DESCRIPTION
Tested by `iex -S mix`:
```
HTTPoison.post("https://httpstat.us/200?sleep=12000", "{}", [], [recv_timeout: 15000, timeout: 15000])
{:ok,
 %HTTPoison.Response{
```
```
HTTPoison.post("https://httpstat.us/200?sleep=12000", "{}", [])
{:error, %HTTPoison.Error{id: nil, reason: :timeout}}
```